### PR TITLE
[DOC] Removed the bug from the Time Series Regression Code block

### DIFF
--- a/docs/source/get_started.rst
+++ b/docs/source/get_started.rst
@@ -117,7 +117,8 @@ Time Series Regression
 
     >>> X_train, y_train = load_covid_3month(split="train")
     >>> y_train = y_train.astype("float")
-    >>> X_test, _ = load_covid_3month(split="test")
+    >>> X_test, y_test = load_covid_3month(split="test")
+    >>> y_test = y_test.astype("float")
     >>> regressor = KNeighborsTimeSeriesRegressor()
     >>> regressor.fit(X_train, y_train)
     >>> y_pred = regressor.predict(X_test)


### PR DESCRIPTION
- fixes #6021

Changed 
```python
X_test, _ = load_covid_3month(split="test")
```
To
```python
X_test, y_test = load_covid_3month(split="test")
y_test = y_test.astype("float")
```
`y_test` was not defined but was used later, also  changed the type of `y_test` to remove the the following ValueError
```md
ValueError: dtype='numeric' is not compatible with arrays of bytes/strings.Convert your data to numeric values explicitly instead.
```